### PR TITLE
Middleware to prevent referrals during maintenance

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,7 +14,6 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \App\Http\Middleware\TrimQuotes::class,
@@ -30,6 +29,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
+            \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
@@ -40,6 +40,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
+            \App\Http\Middleware\PreventReferralsDuringMaintenance::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/app/Http/Middleware/PreventReferralsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventReferralsDuringMaintenance.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+
+class PreventReferralsDuringMaintenance extends PreventRequestsDuringMaintenance
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->is('core/v1/referrals*')) {
+            return parent::handle($request, $next);
+        }
+
+        return $next($request);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,12 +67,12 @@ services:
     command: mysqld --general-log=1 --general-log-file=/var/log/mysql/general-log.log
 
   redis:
-    image: grokzen/redis-cluster:5.0.5
+    image: grokzen/redis-cluster:6.0.16
     volumes:
       - redis-data:/data
 
   redis-testing:
-    image: grokzen/redis-cluster:5.0.5
+    image: grokzen/redis-cluster:6.0.16
 
   elasticsearch:
     image: elasticsearch:7.9.3

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
-use App\Sms\OtpLoginCode\UserSms;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Http\Response;
+use App\Sms\OtpLoginCode\UserSms;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Config;
 
 class LoginTest extends TestCase
 {
@@ -28,5 +29,28 @@ class LoginTest extends TestCase
             $this->assertArrayHasKey('OTP_CODE', $sms->values);
             return true;
         });
+    }
+
+    /**
+    * @test
+    */
+    public function loginWhenApplicationisDownForMaintenance503()
+    {
+        $this->artisan('down');
+
+        $user = factory(User::class)->create(['password' => bcrypt('password')]);
+        factory(\App\Models\Service::class)->create();
+
+        // Login is prevented
+        $this->get(route('login'))->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE);
+        $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE);
+
+        // Other endpoints are available
+        $this->json('GET', '/core/v1/services')->assertStatus(Response::HTTP_OK);
+
+        $this->artisan('up');
     }
 }

--- a/tests/Feature/ReferralsTest.php
+++ b/tests/Feature/ReferralsTest.php
@@ -463,6 +463,41 @@ class ReferralsTest extends TestCase
         });
     }
 
+    /**
+    * @test
+    */
+    public function guestCannotCreateReferralWhenApplicationisDownForMaintenance503()
+    {
+        $this->artisan('down');
+
+        $service = factory(Service::class)->create([
+            'referral_method' => Service::REFERRAL_METHOD_INTERNAL,
+            'referral_email' => $this->faker->safeEmail,
+        ]);
+
+        sleep(1);
+
+        $response = $this->json('POST', '/core/v1/referrals', [
+            'service_id' => $service->id,
+            'name' => $this->faker->name,
+            'email' => $this->faker->safeEmail,
+            'phone' => null,
+            'other_contact' => null,
+            'postcode_outward_code' => null,
+            'comments' => null,
+            'referral_consented' => true,
+            'feedback_consented' => false,
+            'referee_name' => $this->faker->name,
+            'referee_email' => $this->faker->safeEmail,
+            'referee_phone' => random_uk_phone(),
+            'organisation' => $this->faker->company,
+        ]);
+
+        $response->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE);
+
+        $this->artisan('up');
+    }
+
     /*
      * Get a specific referral.
      */


### PR DESCRIPTION
## Summary
https://app.shortcut.com/connected-kingston/story/2524/migration-plan

Prevent admins from logging in and making changes as well as users submitting referrals, yet still allow users to view the frontend

- Move maintenance mode middleware into web middleware from universal. This blocks the login endpoint preventing admins from accessing the admin area.
- Create middleware to block the referrals api endpoint if the app is in maintenance mode but leave all other api endpoints open so the frontend continues to operate